### PR TITLE
[CARE-53] setting swagger for USER-SERVICE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter'
 	// Spring cloud Config
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	// Eureka Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	// Lombok
@@ -61,6 +63,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	//DatabaseCleanUp
 	implementation group: 'com.google.guava', name: 'guava', version: '12.0'
+
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/caring/user_service/common/config/SwaggerConfig.java
+++ b/src/main/java/com/caring/user_service/common/config/SwaggerConfig.java
@@ -1,0 +1,42 @@
+package com.caring.user_service.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "API Document", description = "USER SERVICE 명세서", version = "v3")
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        String jwtSchemeName = "JWT";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .in(SecurityScheme.In.HEADER)
+                        .bearerFormat("Authorization"));
+
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/user-service"))
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+
+}

--- a/src/main/java/com/caring/user_service/common/config/WebMvcConfig.java
+++ b/src/main/java/com/caring/user_service/common/config/WebMvcConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.Arrays;
@@ -35,15 +36,14 @@ public class WebMvcConfig implements WebMvcConfigurer {
         }
     }
 
-//    //CORS setting
-//    @Override
-//    public void addCorsMappings(CorsRegistry registry) {
-//        registry
-//                .addMapping("/**") //CORS 적용할 URL 패턴
-//                .allowedOriginPatterns("*") //자원 공유 오리진 지정
-//                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") //요청 허용 메서드
-//                .allowedHeaders("*") //요청 허용 헤더
-//                .allowCredentials(true) //요청 허용 쿠키
-//                .maxAge(MAX_AGE_SECS);
-//    }
+    //CORS setting
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry
+                .addMapping("/**") //CORS 적용할 URL 패턴
+                .allowedOriginPatterns("http://localhost:8000") //자원 공유 오리진 지정
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS") //요청 허용 메서드
+                .allowedHeaders("*") //요청 허용 헤더
+                .allowCredentials(true); //요청 허용 쿠키
+    }
 }

--- a/src/main/java/com/caring/user_service/common/service/RolesArgumentResolver.java
+++ b/src/main/java/com/caring/user_service/common/service/RolesArgumentResolver.java
@@ -21,7 +21,7 @@ public class RolesArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.getParameterAnnotation(ManagerRoles.class) != null &&
-                (parameter.getParameterType().equals(String.class) || parameter.getParameterType().equals(List.class);
+                (parameter.getParameterType().equals(String.class) || parameter.getParameterType().equals(List.class));
     }
 
     @Override

--- a/src/main/java/com/caring/user_service/presentation/manager/controller/ManagerAccessApiController.java
+++ b/src/main/java/com/caring/user_service/presentation/manager/controller/ManagerAccessApiController.java
@@ -3,9 +3,11 @@ package com.caring.user_service.presentation.manager.controller;
 import com.caring.user_service.presentation.manager.service.ApplyManagerUseCase;
 import com.caring.user_service.presentation.manager.service.RegisterSuperManagerUseCase;
 import com.caring.user_service.presentation.manager.vo.request.RequestManager;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
+@Tag(name = "[매니저(액세스 허용)]")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/api/access/managers")
@@ -14,11 +16,13 @@ public class ManagerAccessApiController {
     private final RegisterSuperManagerUseCase registerSuperManagerUseCase;
     private final ApplyManagerUseCase applyManagerUseCase;
 
+    @Operation(summary = "SUPER 권한을 가진 매니저를 서버에 등록합니다.")
     @PostMapping("/super")
     public Long registerSuperManager(@RequestBody RequestManager requestManager) {
         return registerSuperManagerUseCase.execute(requestManager);
     }
 
+    @Operation(summary = "특정 보호소의 매니저를 신청합니다.")
     @PostMapping("/submissions/shelters/{shelterUuid}")
     public Long applyManager(@PathVariable String shelterUuid,
                              @RequestBody RequestManager requestManager) {

--- a/src/main/java/com/caring/user_service/presentation/manager/controller/ManagerApiController.java
+++ b/src/main/java/com/caring/user_service/presentation/manager/controller/ManagerApiController.java
@@ -8,11 +8,14 @@ import com.caring.user_service.presentation.manager.service.*;
 import com.caring.user_service.presentation.manager.vo.response.ResponseManager;
 import com.caring.user_service.presentation.manager.vo.response.ResponseSpecificManager;
 import com.caring.user_service.presentation.manager.vo.response.ResponseSubmission;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "[매니저(AUTH)]")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/api/managers")
@@ -23,12 +26,14 @@ public class ManagerApiController {
     private final GetShelterStaffUseCase getShelterStaffUseCase;
     private final GetAllManagersUseCase getAllManagersUseCase;
 
+    @Operation(summary = "아직 수락되지 않은 매니저 신청을 조회합니다.")
     @GetMapping("/submissions")
     public List<ResponseSubmission> getPendingSubmissions(@ManagerRoles List<String> roles) {
         RoleUtil.containManagerRole(ManagerRole.SUPER, roles);
         return getPendingSubmissionUseCase.execute();
     }
 
+    @Operation(summary = "매니저 신청을 수락합니다. 이때 수락하는 주체는 SUPER권한을 가지고 있어야합니다.")
     @PostMapping("/submissions/{submissionUuid}/permission")
     public Long permissionRegisteringManager(@PathVariable String submissionUuid,
                                              @ManagerCode String memberCode,
@@ -37,11 +42,13 @@ public class ManagerApiController {
         return permissionRegisteringManagerUseCase.execute(submissionUuid, memberCode);
     }
 
+    @Operation(summary = "보호소 소속 직원(매니저)들을 조회합니다.")
     @GetMapping("/shelters/{shelterUuid}")
     public List<ResponseSpecificManager> getShelterStaff(@PathVariable String shelterUuid) {
         return getShelterStaffUseCase.execute(shelterUuid);
     }
 
+    @Operation(summary = "모든 직원(매니저)들을 조회합니다.")
     @GetMapping("/all")
     public List<ResponseSpecificManager> getAllManagers() {
         return getAllManagersUseCase.execute();

--- a/src/main/java/com/caring/user_service/presentation/security/controller/SecurityAccessApiController.java
+++ b/src/main/java/com/caring/user_service/presentation/security/controller/SecurityAccessApiController.java
@@ -4,6 +4,8 @@ import com.caring.user_service.presentation.security.service.manager.ManagerToke
 import com.caring.user_service.presentation.security.service.user.UserTokenService;
 import com.caring.user_service.presentation.security.vo.JwtToken;
 import com.caring.user_service.presentation.security.vo.RequestLogin;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "[로그인(유저 및 매니저)]")
 @Slf4j
 @RestController
 @RequestMapping("/v1/api/access/tokens")
@@ -20,11 +23,13 @@ public class SecurityAccessApiController {
     private final UserTokenService userTokenService;
     private final ManagerTokenService managerTokenService;
 
+    @Operation(summary = "유저가 로그인을 합니다.")
     @PostMapping("/users")
     public JwtToken loginUser(@RequestBody RequestLogin requestLogin) {
         return userTokenService.login(requestLogin.getMemberCode(), requestLogin.getPassword());
     }
 
+    @Operation(summary = "매니저가 로그인을 합니다.")
     @PostMapping("/managers")
     public JwtToken loginManager(@RequestBody RequestLogin requestLogin) {
         return managerTokenService.login(requestLogin.getMemberCode(), requestLogin.getPassword());

--- a/src/main/java/com/caring/user_service/presentation/shelter/controller/ShelterApiController.java
+++ b/src/main/java/com/caring/user_service/presentation/shelter/controller/ShelterApiController.java
@@ -3,6 +3,8 @@ package com.caring.user_service.presentation.shelter.controller;
 import com.caring.user_service.common.annotation.ManagerCode;
 import com.caring.user_service.presentation.shelter.service.RegisterShelterUseCase;
 import com.caring.user_service.presentation.shelter.vo.RequestShelter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "[보호소(AUTH)]")
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +21,9 @@ public class ShelterApiController {
 
     private final RegisterShelterUseCase registerShelterUseCase;
 
+    @Operation(summary = "보호소를 등록합니다. 이때 등록자(매니저)의 권한은 SUPER가 존재해야 합니다.")
     @PostMapping
+    //TODO use Roles annotation
     public Long registerShelter(@ManagerCode String memberCode,
                                 @RequestBody RequestShelter requestShelter) {
         return registerShelterUseCase.execute(requestShelter, memberCode);

--- a/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
+++ b/src/main/java/com/caring/user_service/presentation/user/controller/UserApiController.java
@@ -8,6 +8,8 @@ import com.caring.user_service.domain.authority.entity.ManagerRole;
 import com.caring.user_service.presentation.user.service.*;
 import com.caring.user_service.presentation.user.vo.RequestUser;
 import com.caring.user_service.presentation.user.vo.ResponseUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "[회원(AUTH)]")
 @Slf4j
 @RestController
 @RequestMapping("/v1/api/users")
@@ -26,7 +29,7 @@ public class UserApiController {
     private final GetUserProfileUseCase getUserProfileUseCase;
     private final GetUsersOfManagerGroupUseCase getUsersOfManagerGroupUseCase;
 
-
+    @Operation(summary = "매니저가 유저 계정을 서버에 등록합니다. 이때 매니저는 SUPER 권한을 가지고 있어야합니다.")
     @PostMapping("/shelters/{shelterUuid}")
     public Long registerUserByManager(@PathVariable String shelterUuid,
                                       @RequestBody RequestUser requestUser,
@@ -35,6 +38,7 @@ public class UserApiController {
         return registerUserByManagerUseCase.execute(requestUser, shelterUuid);
     }
 
+    @Operation(summary = "유저를 매니저 관리 관할에 소속시킵니다.")
     @PostMapping("/{userUuid}/managers/{managerUuid}")
     public Long addUserInManagerGroup(@PathVariable String userUuid,
                                       @PathVariable String managerUuid,
@@ -43,6 +47,7 @@ public class UserApiController {
         return addUserInManagerGroupUseCase.execute(userUuid, managerUuid);
     }
 
+    @Operation(summary = "특정 유저의 계정을 조회합니다.")
     @GetMapping("/{userUuid}")
     public ResponseUser getUserProfile(@PathVariable String userUuid,
                                        @ManagerRoles List<String> roles) {
@@ -50,6 +55,7 @@ public class UserApiController {
         return getUserProfileUseCase.execute(userUuid);
     }
 
+    @Operation(summary = "로그인 중인 매니저의 관리 유저들을 조회합니다.")
     @GetMapping("/grouped")
     public List<ResponseUser> getUsersOfManagerGroup(@ManagerCode String memberCode) {
         return getUsersOfManagerGroupUseCase.execute(memberCode);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,13 @@ management:
     web:
       exposure:
         include: "*"
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html   # Swagger UI 경로 명시
+    enabled: true             # Swagger UI 활성화
+  api-docs:
+    path: /v3/api-docs        # OpenAPI 경로 명시
+  servers:
+    - url: http://localhost:8000/user-service  # Gateway 주소 + prefix
+      description: Gateway를 통한 User-Service API


### PR DESCRIPTION
## #️⃣ 요약 설명
>user-service의 스웨거를 설정하여 게이트웨이에서 사용할 수 있도록 합니다.
## 📝 작업 내용

- https://github.com/green-touch/CARING-Back-User/issues/11

```java
@RequiredArgsConstructor
@Configuration
@OpenAPIDefinition(
        info = @Info(title = "API Document", description = "USER SERVICE 명세서", version = "v3")
)
public class SwaggerConfig {

    @Bean
    public OpenAPI openAPI() {
        String jwtSchemeName = "JWT";
        // API 요청헤더에 인증정보 포함
        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
        // SecuritySchemes 등록
        Components components = new Components()
                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
                        .name(jwtSchemeName)
                        .type(SecurityScheme.Type.HTTP)
                        .scheme("bearer")
                        .in(SecurityScheme.In.HEADER)
                        .bearerFormat("Authorization"));


        return new OpenAPI()
                .addServersItem(new Server().url("/user-service"))
                .addSecurityItem(securityRequirement)
                .components(components);
    }

}

```
### 문제점
CARE-47의 문제점과 동일
